### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -45,7 +45,7 @@ function fish_prompt
 end
 
 function _git_ahead
-  set -l commits (command git rev-list --left-right '@{upstream}...HEAD' ^/dev/null)
+  set -l commits (command git rev-list --left-right '@{upstream}...HEAD' 2>/dev/null)
   if [ $status != 0 ]
     return
   end
@@ -65,10 +65,10 @@ function _git_ahead
 end
 
 function _git_branch_name
-  echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+  echo (command git symbolic-ref HEAD 2>/dev/null | sed -e 's|^refs/heads/||')
 end
 
 function _is_git_dirty
-  echo (command git status -s --ignore-submodules=dirty ^/dev/null)
+  echo (command git status -s --ignore-submodules=dirty 2>/dev/null)
 end
 


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
